### PR TITLE
some tidying for a release of 1.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,9 +4,12 @@ package:
   version: {{ version }}
 
 source:
-  fn: DevIL-{{ version }}.tar.xz
-  url: http://downloads.sourceforge.net/openil/DevIL-{{ version }}.tar.gz
-  sha256: 0075973ee7dd89f0507873e2580ac78336452d29d34a07134b208f44e2feb709
+  fn: DevIL-{{ version }}.tar.gz
+  # https for the sourceforge link times-out intermittently:
+  # url: https://downloads.sourceforge.net/openil/DevIL-{{ version }}.tar.gz
+  # sha256: 0075973ee7dd89f0507873e2580ac78336452d29d34a07134b208f44e2feb709
+  url: https://github.com/DentonW/DevIL/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 52129f247b26fcb5554643c9e6bbee75c4b9717735fdbf3c6ebff08cee38ad37
   patches:
     - patches/fix-jpeg-boolean-usage.patch
 
@@ -45,7 +48,7 @@ about:
   license_file: LICENSE
   summary: 'A full featured cross-platform image library.'
   doc_url: http://openil.sourceforge.net/docs/index.php
-  dev_url: https://sourceforge.net/projects/openil/
+  dev_url: https://github.com/DentonW/DevIL
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,8 +43,8 @@ requirements:
 
 about:
   home: http://openil.sourceforge.net/
-  license: LGPL
-  license_family: GPL
+  license: LGPL-2.1-or-later
+  license_family: LGPL
   license_file: LICENSE
   summary: 'A full featured cross-platform image library.'
   doc_url: http://openil.sourceforge.net/docs/index.php

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,9 @@ source:
     - patches/fix-jpeg-boolean-usage.patch
 
 build:
-  ignore_run_exports:
+  number: 0
   skip: true # [win32]
+  ignore_run_exports:
     - zlib
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   ignore_run_exports:
+  skip: true # [win32]
     - zlib
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   number: 0
-  skip: true # [win32]
+  skip: true # [win32 or s390x]
   ignore_run_exports:
     - zlib
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,9 @@ source:
   patches:
     - patches/fix-jpeg-boolean-usage.patch
 
+build:
+  ignore_run_exports:
+    - zlib
 requirements:
   build:
     - {{ compiler('cxx') }}
@@ -22,9 +25,16 @@ requirements:
     - jpeg
     - zlib
     - libtiff
-    - libmng
     - jasper
-    - lcms2    
+    - lcms2
+
+  run:
+    - libpng
+    - jpeg
+    - zlib
+    - libtiff
+    - jasper
+    - lcms2
 
 about:
   home: http://openil.sourceforge.net/


### PR DESCRIPTION
Note: It needs MFC classes on win64 to build (otherwise it is missing an afxres.h header file)