### PR TITLE
devil 1.8.0: Rebuild with libtiff 4.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
-  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr2/6d62137

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
+  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr2/6d62137

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,9 @@ requirements:
     - jpeg {{ jpeg }}
     - zlib {{ zlib }}
     - libtiff 4.7.0
-    - jasper 4.2.4
+    # jasper 4+ isn't compatible:
+    # $SRC_DIR/DevIL/src-IL/src/il_jp2.cpp:354:9: error: invalid conversion from 'int (*)(jas_stream_obj_t*, char*, int)'
+    - jasper 2.0.14
     - lcms2 2.16
 
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 1
-  skip: true  # [s390x]
   ignore_run_exports:
     - zlib
     - jpeg  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,17 +11,17 @@ source:
 
 build:
   number: 1
-  skip: true # [s390x]
+  skip: true  # [s390x]
   ignore_run_exports:
     - zlib
-    - jpeg # [win]
+    - jpeg  # [win]
 
 requirements:
   build:
     - {{ compiler('cxx') }}
     - cmake
-    - m2-patch # [win]
-    - patch # [not win]
+    - m2-patch  # [win]
+    - patch     # [not win]
     - ninja
   host:
     - libpng {{ libpng }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,21 +4,18 @@ package:
   version: {{ version }}
 
 source:
-  fn: DevIL-{{ version }}.tar.gz
-  # https for the sourceforge link times-out intermittently:
-  # url: https://downloads.sourceforge.net/openil/DevIL-{{ version }}.tar.gz
-  # sha256: 0075973ee7dd89f0507873e2580ac78336452d29d34a07134b208f44e2feb709
   url: https://github.com/DentonW/DevIL/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 52129f247b26fcb5554643c9e6bbee75c4b9717735fdbf3c6ebff08cee38ad37
   patches:
     - patches/fix-jpeg-boolean-usage.patch
 
 build:
-  number: 0
-  skip: true # [win32 or s390x]
+  number: 1
+  skip: true # [s390x]
   ignore_run_exports:
     - zlib
     - jpeg # [win]
+
 requirements:
   build:
     - {{ compiler('cxx') }}
@@ -27,12 +24,12 @@ requirements:
     - patch # [not win]
     - ninja
   host:
-    - libpng
-    - jpeg
-    - zlib
-    - libtiff
-    - jasper
-    - lcms2
+    - libpng {{ libpng }}
+    - jpeg {{ jpeg }}
+    - zlib {{ zlib }}
+    - libtiff 4.7.0
+    - jasper 4.2.4
+    - lcms2 2.16
 
   run:
     - libpng
@@ -43,12 +40,17 @@ requirements:
     - lcms2
 
 about:
-  home: http://openil.sourceforge.net/
+  home: https://openil.sourceforge.net/
   license: LGPL-2.1-or-later
   license_family: LGPL
   license_file: LICENSE
-  summary: 'A full featured cross-platform image library.'
-  doc_url: http://openil.sourceforge.net/docs/index.php
+  summary: A full featured cross-platform image library
+  description: |
+    Developer's Image Library (DevIL) is a cross-platform image library
+    utilizing a simple syntax to load, save, convert, manipulate, filter,
+    and display a variety of images with ease.
+    It is highly portable and has been ported to several platforms.
+  doc_url: https://openil.sourceforge.net/docs/index.php
   dev_url: https://github.com/DentonW/DevIL
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - libpng {{ libpng }}
     - jpeg {{ jpeg }}
     - zlib {{ zlib }}
-    - libtiff 4.7.0
+    - libtiff {{ libtiff }}
     # jasper 4+ isn't compatible:
     # $SRC_DIR/DevIL/src-IL/src/il_jp2.cpp:354:9: error: invalid conversion from 'int (*)(jas_stream_obj_t*, char*, int)'
     - jasper 2.0.14


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7584](https://anaconda.atlassian.net/browse/PKG-7584) 
- [Upstream repository](https://github.com/DentonW/DevIL/tree/v1.8.0)

### Explanation of changes:

- Clean up the recipe
- Bump the build number to 1
- Pin host deps
- Add description

### Notes:

-

[PKG-7584]: https://anaconda.atlassian.net/browse/PKG-7584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ